### PR TITLE
refactor: move update notification from toast to header notification …

### DIFF
--- a/src/components/__tests__/update-notification.test.tsx
+++ b/src/components/__tests__/update-notification.test.tsx
@@ -1,17 +1,6 @@
-import { render, waitFor, act } from '@testing-library/react';
-import { UpdateNotification } from '../update-notification';
-import { setCookieWithMinutes, getCookie, deleteCookie } from '@/lib/cookie-utils'; 
-
-// Mock the useToast hook with actual implementation
-const mockToast = jest.fn();
-const mockDismiss = jest.fn();
-
-jest.mock('@/hooks/use-toast', () => ({
-  useToast: () => ({
-    toast: mockToast,
-    dismiss: mockDismiss,
-  }),
-}));
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useUpdateCheck } from '../update-notification';
+import { setCookieWithMinutes, getCookie, deleteCookie } from '@/lib/cookie-utils';
 
 // Mock fetch for version checking
 const mockFetch = jest.fn();
@@ -20,7 +9,7 @@ global.fetch = mockFetch as jest.Mock;
 // Mock cookie utilities
 jest.mock('@/lib/cookie-utils', () => {
   let cookieStore: Record<string, string> = {};
-  
+
   return {
     setCookieWithMinutes: jest.fn((name: string, value: string, minutes: number) => {
       const expiration = new Date();
@@ -30,7 +19,7 @@ jest.mock('@/lib/cookie-utils', () => {
     getCookie: jest.fn((name: string) => {
       const cookie = cookieStore[name];
       if (!cookie) return null;
-      
+
       // Check if cookie is expired
       const [value, expires] = cookie.split(';expires=');
       if (expires && new Date(expires) < new Date()) {
@@ -45,132 +34,69 @@ jest.mock('@/lib/cookie-utils', () => {
   };
 });
 
-describe('UpdateNotification Component', () => {
+describe('useUpdateCheck Hook', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.useFakeTimers();
-    
+
     // Reset cookies
     const { deleteCookie } = require('@/lib/cookie-utils');
     deleteCookie('update_dismissed');
-    
+
     // Setup fetch mock
     mockFetch.mockResolvedValue({
       json: async () => ({ version: '1.0.3', date: '2025-08-10' }),
     });
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
   describe('Version checking', () => {
-    it('should check for updates when component mounts', async () => {
-      render(<UpdateNotification currentVersion="1.0.2" />);
-      
+    it('should check for updates when hook mounts', async () => {
+      renderHook(() => useUpdateCheck());
+
       await waitFor(() => {
         expect(mockFetch).toHaveBeenCalledWith('/version.json');
       });
     });
 
-    it('should show notification when new version is available', async () => {
-      render(<UpdateNotification currentVersion="1.0.2" />);
-      
+    it('should set hasUpdate to true when new version is available', async () => {
+      // First call returns current version, second call returns latest
+      mockFetch
+        .mockResolvedValueOnce({ json: async () => ({ version: '1.0.2' }) })
+        .mockResolvedValueOnce({ json: async () => ({ version: '1.0.3' }) });
+
+      const { result } = renderHook(() => useUpdateCheck());
+
       await waitFor(() => {
-        expect(mockToast).toHaveBeenCalledWith(
-          expect.objectContaining({
-            title: 'Nueva versión disponible',
-            description: 'Actualiza para obtener las últimas mejoras',
-          })
-        );
+        expect(result.current.hasUpdate).toBe(true);
       });
     });
 
-    it('should not show notification when versions match', async () => {
+    it('should not set hasUpdate when versions match', async () => {
       mockFetch.mockResolvedValue({
-        json: async () => ({ version: '1.0.2', date: '2025-08-10' }),
+        json: async () => ({ version: '1.0.2' }),
       });
 
-      render(<UpdateNotification currentVersion="1.0.2" />);
-      
-      // Wait for fetch to complete
+      const { result } = renderHook(() => useUpdateCheck());
+
       await waitFor(() => {
         expect(mockFetch).toHaveBeenCalled();
       });
-      
-      // Should not show notification
-      expect(mockToast).not.toHaveBeenCalled();
+
+      expect(result.current.hasUpdate).toBe(false);
     });
   });
 
   describe('Cookie handling', () => {
-    it('should not show notification if cookie exists and not expired', async () => {
+    it('should not set hasUpdate if cookie exists and not expired', async () => {
       const { getCookie } = require('@/lib/cookie-utils');
       (getCookie as jest.Mock).mockReturnValue('true');
 
-      render(<UpdateNotification currentVersion="1.0.2" />);
-      
+      const { result } = renderHook(() => useUpdateCheck());
+
       await waitFor(() => {
         expect(mockFetch).toHaveBeenCalled();
       });
-      
-      expect(mockToast).not.toHaveBeenCalled();
-    });
 
-    it('should show notification if cookie is expired', async () => {
-      const { getCookie } = require('@/lib/cookie-utils');
-      (getCookie as jest.Mock).mockReturnValue(null); // Expired
-
-      render(<UpdateNotification currentVersion="1.0.2" />);
-      
-      await waitFor(() => {
-        expect(mockToast).toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('Dismissal behavior', () => {
-    it('should set cookie when notification is dismissed', async () => {
-      const { setCookieWithMinutes } = require('@/lib/cookie-utils');
-      
-      render(<UpdateNotification currentVersion="1.0.2" />);
-      
-      await waitFor(() => {
-        expect(mockToast).toHaveBeenCalled();
-      });
-
-      // Simulate dismissal
-      const toastCall = mockToast.mock.calls[0][0];
-      const closeAction = toastCall.action;
-      
-      act(() => {
-        closeAction.props.onClick();
-      });
-      
-      expect(setCookieWithMinutes).toHaveBeenCalledWith('update_dismissed', 'true', 30);
-      expect(mockDismiss).toHaveBeenCalled();
-    });
-
-    it('should reload page when update is clicked', async () => {
-      const reloadSpy = jest.spyOn(window.location, 'reload');
-      
-      render(<UpdateNotification currentVersion="1.0.2" />);
-      
-      await waitFor(() => {
-        expect(mockToast).toHaveBeenCalled();
-      });
-
-      // Simulate update click
-      const toastCall = mockToast.mock.calls[0][0];
-      const updateAction = toastCall.action;
-      
-      act(() => {
-        updateAction.props.onClick();
-      });
-      
-      expect(reloadSpy).toHaveBeenCalled();
-      
-      reloadSpy.mockRestore();
+      expect(result.current.hasUpdate).toBe(false);
     });
   });
 
@@ -178,14 +104,13 @@ describe('UpdateNotification Component', () => {
     it('should handle fetch errors gracefully', async () => {
       mockFetch.mockRejectedValue(new Error('Network error'));
 
-      render(<UpdateNotification currentVersion="1.0.2" />);
-      
-      // Should not crash or show notification on error
+      const { result } = renderHook(() => useUpdateCheck());
+
       await waitFor(() => {
         expect(mockFetch).toHaveBeenCalled();
       });
-      
-      expect(mockToast).not.toHaveBeenCalled();
+
+      expect(result.current.hasUpdate).toBe(false);
     });
 
     it('should handle invalid version.json format', async () => {
@@ -193,51 +118,13 @@ describe('UpdateNotification Component', () => {
         json: async () => ({ invalid: 'format' }),
       });
 
-      render(<UpdateNotification currentVersion="1.0.2" />);
-      
+      const { result } = renderHook(() => useUpdateCheck());
+
       await waitFor(() => {
         expect(mockFetch).toHaveBeenCalled();
       });
-      
-      expect(mockToast).not.toHaveBeenCalled();
-    });
-  });
 
-  describe('30-minute expiration', () => {
-    it('should show notification again after 30 minutes', async () => {
-      const { setCookieWithMinutes, getCookie } = require('@/lib/cookie-utils');
-      
-      render(<UpdateNotification currentVersion="1.0.2" />);
-      
-      await waitFor(() => {
-        expect(mockToast).toHaveBeenCalled();
-      });
-
-      // Simulate dismissal
-      const toastCall = mockToast.mock.calls[0][0];
-      const closeAction = toastCall.action;
-      
-      act(() => {
-        closeAction.props.onClick();
-      });
-
-      // Advance time by 31 minutes
-      act(() => {
-        jest.advanceTimersByTime(31 * 60 * 1000);
-      });
-
-      // Reset mocks to test second render
-      mockToast.mockClear();
-      
-      // Re-render component
-      render(<UpdateNotification currentVersion="1.0.2" />);
-      
-      // Cookie should be expired
-      (getCookie as jest.Mock).mockReturnValue(null);
-      
-      await waitFor(() => {
-        expect(mockToast).toHaveBeenCalled();
-      });
+      expect(result.current.hasUpdate).toBe(false);
     });
   });
 });

--- a/src/components/main-layout.tsx
+++ b/src/components/main-layout.tsx
@@ -40,7 +40,6 @@ import { signOut } from "firebase/auth";
 import { useToast } from "@/hooks/use-toast";
 import { NotificationBell } from "./notification-bell";
 import { ChangelogDialog } from "./changelog-dialog";
-import { UpdateNotification } from "./update-notification";
 import { InstallPrompt } from "@/components/install-prompt";
 import { navigationItems } from "@/lib/navigation";
 import { usersCollection } from "@/lib/collections";
@@ -233,7 +232,6 @@ export function MainLayout({ children }: { children: ReactNode }) {
 
   return (
     <>
-      <UpdateNotification />
       <Sidebar collapsible="icon">
         <SidebarHeader>
           <Logo />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -79,6 +79,8 @@
   "Mobile Push Notifications": "Mobile Push Notifications",
   "Receive push notifications on your Android/iOS device even when the app is closed.": "Receive push notifications on your Android/iOS device even when the app is closed.",
   "Notification settings are not available yet.": "Notification settings are not available yet.",
+  "updateNotification.title": "New version available",
+  "updateNotification.body": "There are improvements available. Update to enjoy them.",
   "updateNotification.dismiss": "Dismiss",
   "updateNotification.update": "Update",
   "serviceWorker.reload": "Reload",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -78,6 +78,8 @@
   "Mobile Push Notifications": "Notificaciones Push Móvil",
   "Receive push notifications on your Android/iOS device even when the app is closed.": "Recibe notificaciones push en tu dispositivo Android/iOS incluso cuando la app esté cerrada.",
   "Notification settings are not available yet.": "Los ajustes de notificaciones aún no están disponibles.",
+  "updateNotification.title": "Nueva versión disponible",
+  "updateNotification.body": "Hay mejoras disponibles. Actualiza para disfrutarlas.",
   "updateNotification.dismiss": "Cerrar",
   "updateNotification.update": "Actualizar",
   "serviceWorker.reload": "Recargar",


### PR DESCRIPTION
…bell

The update available notification was previously shown as a toast/banner at the top of the page. Now it appears inside the notification bell popover in the header, keeping the UI cleaner and consistent with the existing notification system.

- Refactored UpdateNotification component into a useUpdateCheck hook
- Integrated update notification into NotificationBell popover
- Added translation keys for notification title and body
- Updated tests to match the new hook-based API

https://claude.ai/code/session_019GHxW8ST7XrEW3kmHGB1Mz