### PR TITLE
🔒 [security fix] Restrict public read access in Storage rules

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -7,10 +7,10 @@ service firebase.storage {
     match /{allPaths=**} {
       
       // PERMISOS DE LECTURA
-      // Permite la lectura a cualquier usuario (público).
-      // Esto es generalmente seguro y necesario para que las imágenes se muestren
-      // en la aplicación sin que cada usuario necesite permisos individuales.
-      allow read;
+      // Solo permite la lectura a usuarios autenticados.
+      // Esto protege los archivos de accesos no autorizados mientras permite
+      // que los usuarios registrados vean las imágenes necesarias.
+      allow read: if request.auth != null;
 
       // PERMISOS DE ESCRITURA (Crear, Actualizar, Eliminar)
       // Solo permite la escritura si se cumplen TODAS las siguientes condiciones:


### PR DESCRIPTION
🎯 **What:** Fixed an insecure Firebase Storage rule that allowed unrestricted public read access (`allow read;`) to all files in the bucket.

⚠️ **Risk:** Public read access allows anyone with the bucket URL to access all stored files without authentication. This could lead to the exposure of sensitive user-uploaded content, such as member photos or documents.

🛡️ **Solution:** Updated the rules to require user authentication for all read requests (`allow read: if request.auth != null;`). This ensures that only authorized users of the application can view the stored files.

---
*PR created automatically by Jules for task [8038136083312661270](https://jules.google.com/task/8038136083312661270) started by @AndresDevelopers*