### PR TITLE
🧪 Role verification tests for roles.ts

### DIFF
--- a/src/lib/__tests__/roles.test.ts
+++ b/src/lib/__tests__/roles.test.ts
@@ -1,0 +1,67 @@
+import {
+  canManageSettings,
+  hasLeadershipPrivileges,
+  canViewSettings,
+  normalizeRole,
+} from '@/lib/roles';
+import type { UserRole } from '@/lib/roles';
+
+describe('normalizeRole', () => {
+  it('normalizes roles correctly', () => {
+    expect(normalizeRole('secretary')).toBe('secretary');
+    expect(normalizeRole('admin')).toBe('secretary');
+    expect(normalizeRole('president')).toBe('president');
+    expect(normalizeRole('presidente')).toBe('president');
+    expect(normalizeRole('counselor')).toBe('counselor');
+    expect(normalizeRole('consejero')).toBe('counselor');
+    expect(normalizeRole('consejera')).toBe('counselor');
+    expect(normalizeRole('other')).toBe('other');
+    expect(normalizeRole('otro')).toBe('other');
+  });
+
+  it('defaults to user for unknown roles', () => {
+    expect(normalizeRole('unknown')).toBe('user');
+    expect(normalizeRole('')).toBe('user');
+    expect(normalizeRole(undefined)).toBe('user');
+    expect(normalizeRole(null)).toBe('user');
+  });
+});
+
+describe('canManageSettings', () => {
+  it('allows secretary to manage settings', () => {
+    expect(canManageSettings('secretary')).toBe(true);
+  });
+
+  it('denies other roles from managing settings', () => {
+    expect(canManageSettings('president' as UserRole)).toBe(false);
+    expect(canManageSettings('counselor' as UserRole)).toBe(false);
+    expect(canManageSettings('user' as UserRole)).toBe(false);
+    expect(canManageSettings('other' as UserRole)).toBe(false);
+  });
+});
+
+describe('hasLeadershipPrivileges', () => {
+  it('returns true for leadership roles', () => {
+    expect(hasLeadershipPrivileges('secretary')).toBe(true);
+    expect(hasLeadershipPrivileges('president')).toBe(true);
+    expect(hasLeadershipPrivileges('counselor')).toBe(true);
+  });
+
+  it('returns false for non-leadership roles', () => {
+    expect(hasLeadershipPrivileges('user')).toBe(false);
+    expect(hasLeadershipPrivileges('other')).toBe(false);
+  });
+});
+
+describe('canViewSettings', () => {
+  it('allows leadership roles to view settings', () => {
+    expect(canViewSettings('secretary')).toBe(true);
+    expect(canViewSettings('president')).toBe(true);
+    expect(canViewSettings('counselor')).toBe(true);
+  });
+
+  it('denies non-leadership roles from viewing settings', () => {
+    expect(canViewSettings('user')).toBe(false);
+    expect(canViewSettings('other')).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR addresses the testing gap for the role verification logic in `src/lib/roles.ts`.

### 🎯 What:
Unit tests have been added for the following functions:
- `canManageSettings`: Ensures only the `settingsAdminRole` (secretary) can manage settings.
- `hasLeadershipPrivileges`: Verifies that leadership roles (secretary, president, counselor) have appropriate privileges.
- `canViewSettings`: Confirms that leadership roles can view settings.
- `normalizeRole`: Tests the normalization and translation logic for various role strings.

### 📊 Coverage:
- Happy paths for all role types.
- Spanish translation variants for roles (e.g., "presidente", "consejero").
- Edge cases for unknown or missing role inputs.

### ✨ Result:
The addition of these tests increases the reliability of the application's authorization logic and ensures that role-based access control remains consistent during future refactors.

---
*PR created automatically by Jules for task [11123545172885911836](https://jules.google.com/task/11123545172885911836) started by @AndresDevelopers*