### PR TITLE
⚡ [performance] Optimize ministering reverse sync by batching Firestore queries

### DIFF
--- a/src/lib/ministering-reverse-sync.ts
+++ b/src/lib/ministering-reverse-sync.ts
@@ -10,6 +10,38 @@ import type { Member } from './types';
 import logger from './logger';
 
 /**
+ * Obtiene los miembros de varias familias en lotes de 30 (límite de Firestore para la cláusula 'in')
+ * @param familyNames - Nombres de las familias a buscar
+ * @returns Map donde la clave es el apellido y el valor es el array de miembros
+ */
+async function getMembersByFamilies(familyNames: string[]): Promise<Map<string, Member[]>> {
+  const lastNamesMap = new Map<string, Member[]>();
+  if (familyNames.length === 0) return lastNamesMap;
+
+  // Extraer apellidos únicos
+  const uniqueLastNames = [...new Set(familyNames.map(f => f.replace('Familia ', '').trim()))];
+
+  // Firestore permite hasta 30 elementos en una cláusula 'in'
+  const CHUNK_SIZE = 30;
+  for (let i = 0; i < uniqueLastNames.length; i += CHUNK_SIZE) {
+    const batch = uniqueLastNames.slice(i, i + CHUNK_SIZE);
+    const memberQuery = query(membersCollection, where('lastName', 'in', batch));
+    const memberSnap = await getDocs(memberQuery);
+
+    memberSnap.forEach((doc) => {
+      const member = { id: doc.id, ...doc.data() } as Member;
+      const lastName = member.lastName;
+      if (!lastNamesMap.has(lastName)) {
+        lastNamesMap.set(lastName, []);
+      }
+      lastNamesMap.get(lastName)!.push(member);
+    });
+  }
+
+  return lastNamesMap;
+}
+
+/**
  * Elimina los maestros ministrantes de las familias cuando se elimina un compañerismo
  * @param companionNames - Nombres de los compañeros del compañerismo eliminado
  * @param familyNames - Nombres de las familias asignadas
@@ -26,43 +58,38 @@ export async function removeMinisteringTeachersFromFamilies(
       families: familyNames
     });
 
-    const batch = writeBatch(firestore);
+    let batch = writeBatch(firestore);
     let batchCount = 0;
 
+    const membersByFamilies = await getMembersByFamilies(familyNames);
+
     for (const familyName of familyNames) {
-      // Extraer el apellido de "Familia Apellido"
       const lastName = familyName.replace('Familia ', '').trim();
-      
-      // Buscar miembros con ese apellido
-      const memberQuery = query(membersCollection, where('lastName', '==', lastName));
-      const memberSnap = await getDocs(memberQuery);
+      const members = membersByFamilies.get(lastName) || [];
 
-      if (!memberSnap.empty) {
-        for (const memberDoc of memberSnap.docs) {
-          const member = { id: memberDoc.id, ...memberDoc.data() } as Member;
-          
-          if (member.ministeringTeachers && member.ministeringTeachers.length > 0) {
-            // Filtrar los maestros que pertenecen a este compañerismo
-            const updatedTeachers = member.ministeringTeachers.filter(
-              teacher => !normalizedCompanions.includes(teacher.trim().toLowerCase())
-            );
+      for (const member of members) {
+        if (member.ministeringTeachers && member.ministeringTeachers.length > 0) {
+          // Filtrar los maestros que pertenecen a este compañerismo
+          const updatedTeachers = member.ministeringTeachers.filter(
+            teacher => !normalizedCompanions.includes(teacher.trim().toLowerCase())
+          );
 
-            // Solo actualizar si hubo cambios
-            if (updatedTeachers.length !== member.ministeringTeachers.length) {
-              console.log(`  ✏️ Updating ${member.firstName} ${member.lastName}:`, {
-                before: member.ministeringTeachers,
-                after: updatedTeachers
-              });
+          // Solo actualizar si hubo cambios
+          if (updatedTeachers.length !== member.ministeringTeachers.length) {
+            console.log(`  ✏️ Updating ${member.firstName} ${member.lastName}:`, {
+              before: member.ministeringTeachers,
+              after: updatedTeachers
+            });
 
-              const memberRef = doc(membersCollection, member.id);
-              batch.update(memberRef, { ministeringTeachers: updatedTeachers });
-              batchCount++;
+            const memberRef = doc(membersCollection, member.id);
+            batch.update(memberRef, { ministeringTeachers: updatedTeachers });
+            batchCount++;
 
-              // Ejecutar batch si alcanzamos el límite
-              if (batchCount >= 500) {
-                await batch.commit();
-                batchCount = 0;
-              }
+            // Ejecutar batch si alcanzamos el límite
+            if (batchCount >= 500) {
+              await batch.commit();
+              batch = writeBatch(firestore);
+              batchCount = 0;
             }
           }
         }
@@ -111,31 +138,40 @@ export async function updateMinisteringTeachersOnCompanionshipChange(
     // Familias que permanecen pero los compañeros cambiaron
     const remainingFamilies = oldFamilies.filter(f => newFamilies.includes(f));
 
-    const batch = writeBatch(firestore);
+    let batch = writeBatch(firestore);
     let batchCount = 0;
+
+    // Helper to commit batch and reset
+    const maybeCommit = async () => {
+      if (batchCount >= 500) {
+        await batch.commit();
+        batch = writeBatch(firestore);
+        batchCount = 0;
+      }
+    };
+
+    // Obtener todos los miembros necesarios de una sola vez
+    const allUniqueFamilies = [...new Set([...removedFamilies, ...addedFamilies, ...remainingFamilies])];
+    const membersByFamilies = await getMembersByFamilies(allUniqueFamilies);
 
     // 1. Eliminar maestros de las familias removidas
     if (removedFamilies.length > 0) {
       for (const familyName of removedFamilies) {
         const lastName = familyName.replace('Familia ', '').trim();
-        const memberQuery = query(membersCollection, where('lastName', '==', lastName));
-        const memberSnap = await getDocs(memberQuery);
+        const members = membersByFamilies.get(lastName) || [];
 
-        if (!memberSnap.empty) {
-          for (const memberDoc of memberSnap.docs) {
-            const member = { id: memberDoc.id, ...memberDoc.data() } as Member;
-            
-            if (member.ministeringTeachers && member.ministeringTeachers.length > 0) {
-              const updatedTeachers = member.ministeringTeachers.filter(
-                teacher => !oldCompanions.includes(teacher)
-              );
+        for (const member of members) {
+          if (member.ministeringTeachers && member.ministeringTeachers.length > 0) {
+            const updatedTeachers = member.ministeringTeachers.filter(
+              teacher => !oldCompanions.includes(teacher)
+            );
 
-              if (updatedTeachers.length !== member.ministeringTeachers.length) {
-                console.log(`  ➖ Removing from ${member.firstName} ${member.lastName}`);
-                const memberRef = doc(membersCollection, member.id);
-                batch.update(memberRef, { ministeringTeachers: updatedTeachers });
-                batchCount++;
-              }
+            if (updatedTeachers.length !== member.ministeringTeachers.length) {
+              console.log(`  ➖ Removing from ${member.firstName} ${member.lastName}`);
+              const memberRef = doc(membersCollection, member.id);
+              batch.update(memberRef, { ministeringTeachers: updatedTeachers });
+              batchCount++;
+              await maybeCommit();
             }
           }
         }
@@ -146,21 +182,18 @@ export async function updateMinisteringTeachersOnCompanionshipChange(
     if (addedFamilies.length > 0) {
       for (const familyName of addedFamilies) {
         const lastName = familyName.replace('Familia ', '').trim();
-        const memberQuery = query(membersCollection, where('lastName', '==', lastName));
-        const memberSnap = await getDocs(memberQuery);
+        const members = membersByFamilies.get(lastName) || [];
 
-        if (!memberSnap.empty) {
-          for (const memberDoc of memberSnap.docs) {
-            const member = { id: memberDoc.id, ...memberDoc.data() } as Member;
-            const currentTeachers = member.ministeringTeachers || [];
-            const newTeachers = [...new Set([...currentTeachers, ...newCompanions])];
+        for (const member of members) {
+          const currentTeachers = member.ministeringTeachers || [];
+          const newTeachers = [...new Set([...currentTeachers, ...newCompanions])];
 
-            if (newTeachers.length !== currentTeachers.length) {
-              console.log(`  ➕ Adding to ${member.firstName} ${member.lastName}`);
-              const memberRef = doc(membersCollection, member.id);
-              batch.update(memberRef, { ministeringTeachers: newTeachers });
-              batchCount++;
-            }
+          if (newTeachers.length !== currentTeachers.length) {
+            console.log(`  ➕ Adding to ${member.firstName} ${member.lastName}`);
+            const memberRef = doc(membersCollection, member.id);
+            batch.update(memberRef, { ministeringTeachers: newTeachers });
+            batchCount++;
+            await maybeCommit();
           }
         }
       }
@@ -172,24 +205,21 @@ export async function updateMinisteringTeachersOnCompanionshipChange(
     if (companionsChanged && remainingFamilies.length > 0) {
       for (const familyName of remainingFamilies) {
         const lastName = familyName.replace('Familia ', '').trim();
-        const memberQuery = query(membersCollection, where('lastName', '==', lastName));
-        const memberSnap = await getDocs(memberQuery);
+        const members = membersByFamilies.get(lastName) || [];
 
-        if (!memberSnap.empty) {
-          for (const memberDoc of memberSnap.docs) {
-            const member = { id: memberDoc.id, ...memberDoc.data() } as Member;
-            const currentTeachers = member.ministeringTeachers || [];
-            
-            // Remover compañeros antiguos y agregar nuevos
-            const withoutOld = currentTeachers.filter(t => !oldCompanions.includes(t));
-            const updatedTeachers = [...new Set([...withoutOld, ...newCompanions])];
+        for (const member of members) {
+          const currentTeachers = member.ministeringTeachers || [];
 
-            if (JSON.stringify(updatedTeachers.sort()) !== JSON.stringify(currentTeachers.sort())) {
-              console.log(`  🔄 Updating ${member.firstName} ${member.lastName}`);
-              const memberRef = doc(membersCollection, member.id);
-              batch.update(memberRef, { ministeringTeachers: updatedTeachers });
-              batchCount++;
-            }
+          // Remover compañeros antiguos y agregar nuevos
+          const withoutOld = currentTeachers.filter(t => !oldCompanions.includes(t));
+          const updatedTeachers = [...new Set([...withoutOld, ...newCompanions])];
+
+          if (JSON.stringify(updatedTeachers.sort()) !== JSON.stringify(currentTeachers.sort())) {
+            console.log(`  🔄 Updating ${member.firstName} ${member.lastName}`);
+            const memberRef = doc(membersCollection, member.id);
+            batch.update(memberRef, { ministeringTeachers: updatedTeachers });
+            batchCount++;
+            await maybeCommit();
           }
         }
       }


### PR DESCRIPTION
### 💡 What
This PR optimizes the performance of the ministering reverse sync logic by refactoring sequential Firestore queries into batched queries. It also fixes a critical bug in the write batch management logic.

### 🎯 Why
The original implementation performed a separate `getDocs` query for every family being processed in a loop. For users with many family assignments, this resulted in an N+1 query problem, leading to poor performance and unnecessary database load. Additionally, the existing batch update logic failed to reset the `writeBatch` object after committing, which would cause errors when processing more than 500 updates.

### 📊 Measured Improvement
- **Query Complexity:** Reduced from $O(N)$ to $O(N/30)$ queries (where $N$ is the number of families).
- **Network Round-trips:** Significant reduction in latency by minimizing the number of distinct database requests.
- **Reliability:** Fixed batch management to safely handle synchronization of large datasets (500+ members).

---
*PR created automatically by Jules for task [501311338603158519](https://jules.google.com/task/501311338603158519) started by @AndresDevelopers*