### PR TITLE
🧹 fix(date-utils): change `any` to `unknown` in getAge parameter

### DIFF
--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -94,7 +94,7 @@ export function isPastDate(timestamp: any): boolean {
  * @param birthTimestamp - The birth date timestamp
  * @returns Age in years or null if invalid
  */
-export function getAge(birthTimestamp: any): number | null {
+export function getAge(birthTimestamp: unknown): number | null {
     const birthDate = safeGetDate(birthTimestamp);
     if (!birthDate) return null;
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Changed the type of the `birthTimestamp` parameter in the `getAge` function from `any` to `unknown`.

💡 **Why:** How this improves maintainability
Using `any` disables type checking and can lead to unexpected runtime errors. By using `unknown`, we indicate that the parameter can be of any type, but we must perform type checking or use a utility function (like `safeGetDate`) to safely handle it before use. This improves type safety and code readability without altering functionality.

✅ **Verification:** How you confirmed the change is safe
Ran `pnpm run typecheck` which completed successfully with no type errors. The `birthTimestamp` is passed to the existing `safeGetDate` function which handles parsing and returns a standard `Date` object or `null`, so runtime functionality is unaffected.

✨ **Result:** The improvement achieved
A safer type signature for the `getAge` function that prevents accidental misuse and aligns better with TypeScript best practices.

---
*PR created automatically by Jules for task [15873690507879285296](https://jules.google.com/task/15873690507879285296) started by @AndresDevelopers*