### PR TITLE
🧹 fix: remove any casts in members-data updateMember

### DIFF
--- a/src/lib/members-data.ts
+++ b/src/lib/members-data.ts
@@ -208,12 +208,12 @@ export async function updateMember(
       deathDate: memberData.deathDate,
       baptismPhotos: memberData.baptismPhotos,
       ordinances: memberData.ordinances,
-      templeOrdinances: (memberData as any).templeOrdinances,
-      templeWorkCompletedAt: (memberData as any).templeWorkCompletedAt,
+      templeOrdinances: memberData.templeOrdinances,
+      templeWorkCompletedAt: memberData.templeWorkCompletedAt,
       ministeringTeachers: memberData.ministeringTeachers,
       isUrgent: memberData.isUrgent,
       urgentReason: memberData.urgentReason,
-      urgentNotifiedAt: (memberData as any).urgentNotifiedAt,
+      urgentNotifiedAt: memberData.urgentNotifiedAt,
       isInCouncil: memberData.isInCouncil,
     };
 


### PR DESCRIPTION
🎯 **What:** Removed explicit `any` casting when reading properties `templeOrdinances`, `templeWorkCompletedAt`, and `urgentNotifiedAt` from the `memberData` object in the `updateMember` function of `src/lib/members-data.ts`.
💡 **Why:** Casting to `any` bypasses TypeScript's type checking, making the code more error-prone. These properties are correctly typed as optional fields on the `Member` interface in `src/lib/types.ts`, meaning the cast is unnecessary and an anti-pattern. Removing it improves type safety and overall code maintainability.
✅ **Verification:** Ran `pnpm run typecheck` to ensure the removal of the cast did not introduce any compilation errors. Also successfully ran `pnpm run lint`.
✨ **Result:** The `updateMember` function now safely accesses fields from `memberData` leveraging its proper interface definition, eliminating the `any` anti-pattern for these properties.

---
*PR created automatically by Jules for task [16639549103392543614](https://jules.google.com/task/16639549103392543614) started by @AndresDevelopers*