### PR TITLE
🧹 Fix empty catch blocks in firebase-admin.ts

### DIFF
--- a/src/lib/__tests__/firebase-admin.test.ts
+++ b/src/lib/__tests__/firebase-admin.test.ts
@@ -1,0 +1,52 @@
+// parseServiceAccountKey unit tests
+import { parseServiceAccountKey } from '../firebase-admin';
+
+describe('parseServiceAccountKey', () => {
+  const validConfig = {
+    project_id: 'test-project',
+    private_key: '-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n',
+    client_email: 'test@example.com',
+  };
+  const validJson = JSON.stringify(validConfig);
+
+  it('parses valid JSON string', () => {
+    const result = parseServiceAccountKey(validJson);
+    expect(result).toMatchObject({
+      projectId: 'test-project',
+      project_id: 'test-project',
+    });
+  });
+
+  it('parses valid base64 encoded JSON string', () => {
+    const base64Json = Buffer.from(validJson).toString('base64');
+    const result = parseServiceAccountKey(base64Json);
+    expect(result).toMatchObject({
+      projectId: 'test-project',
+    });
+  });
+
+  it('parses JSON with quoted string', () => {
+    const quotedJson = `"${validJson.replace(/"/g, '\\"')}"`;
+    const result = parseServiceAccountKey(quotedJson);
+    expect(result).toMatchObject({
+      projectId: 'test-project',
+    });
+  });
+
+  it('returns null for invalid inputs', () => {
+    expect(parseServiceAccountKey('not-a-json')).toBeNull();
+    expect(parseServiceAccountKey('')).toBeNull();
+    expect(parseServiceAccountKey('{}')).toBeNull();
+  });
+
+  it('normalizes private key with literal newlines', () => {
+    const configWithLiteralNewlines = {
+      ...validConfig,
+      private_key: '-----BEGIN PRIVATE KEY-----\nline1\nline2\n-----END PRIVATE KEY-----\n'
+    };
+    const mangledJson = JSON.stringify(configWithLiteralNewlines).replace(/\\n/g, '\n');
+    const result = parseServiceAccountKey(mangledJson);
+    expect(result).not.toBeNull();
+    expect(result?.private_key).toContain('\\n');
+  });
+});

--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import logger from './logger';
 import { initializeApp, getApps, cert, type App, type ServiceAccount } from 'firebase-admin/app';
 import { getFirestore, type Firestore } from 'firebase-admin/firestore';
 import { getStorage, type Storage } from 'firebase-admin/storage';
@@ -14,7 +15,7 @@ let warnedMissingServiceAccount = false;
 
 type ServiceAccountWithLegacy = ServiceAccount & { project_id?: string };
 
-function parseServiceAccountKey(value: string): ServiceAccountWithLegacy | null {
+export function parseServiceAccountKey(value: string): ServiceAccountWithLegacy | null {
   const trimmed = value.trim();
   const candidates: string[] = [];
   const maybeJsonPath = trimmed.endsWith('.json') ? trimmed : '';
@@ -31,14 +32,18 @@ function parseServiceAccountKey(value: string): ServiceAccountWithLegacy | null 
     if (/^[A-Za-z0-9+/=]+$/.test(compact) && compact.length % 4 === 0) {
       try {
         candidates.push(Buffer.from(compact, 'base64').toString('utf8'));
-      } catch {}
+      } catch (error) {
+        logger.debug({ message: 'Failed to decode base64 service account candidate', error });
+      }
     }
   }
 
   if (maybeJsonPath && fs.existsSync(maybeJsonPath)) {
     try {
       candidates.push(fs.readFileSync(maybeJsonPath, 'utf8'));
-    } catch {}
+    } catch (error) {
+      logger.debug({ message: 'Failed to read service account from path', error });
+    }
   }
 
   const normalizePrivateKey = (candidate: string) => {
@@ -63,7 +68,9 @@ function parseServiceAccountKey(value: string): ServiceAccountWithLegacy | null 
           parsed.projectId = parsed.project_id;
         }
         return parsed;
-      } catch {}
+      } catch (error) {
+        logger.debug({ message: 'Failed to parse service account JSON even after key normalization', error });
+      }
     }
   }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is "Empty Catch Block" in `src/lib/firebase-admin.ts`. Errors during service account key parsing were being silently swallowed.

💡 **Why:** Errors should never be silently swallowed as it makes debugging difficult. Logging these errors at a `debug` level ensures they are available when needed without cluttering production logs during the normal "trial-and-error" parsing process.

✅ **Verification:**
- Created a unit test `src/lib/__tests__/firebase-admin.test.ts` to verify `parseServiceAccountKey` logic.
- Ran a verification script that confirmed valid JSON and Base64 inputs still work, and invalid inputs now trigger the logger calls.
- Verified indentation and exported the utility for better maintainability.

✨ **Result:** Improved maintainability and traceability of the Firebase Admin initialization process.

---
*PR created automatically by Jules for task [15671165798686013343](https://jules.google.com/task/15671165798686013343) started by @AndresDevelopers*