### PR TITLE
🧹 remove redundant Firebase SDK TODO

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -5,8 +5,6 @@ import { getFirestore } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
 import { getFunctions } from "firebase/functions";
 import { firebaseConfig } from "@/firebaseConfig"; // Import config from the new file
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
 
 // Initialize Firebase app on both server and client
 let app: ReturnType<typeof getApp> | undefined;


### PR DESCRIPTION
### 🎯 What
Removed the redundant `// TODO: Add SDKs for Firebase products that you want to use` comment and its documentation link from `src/lib/firebase.ts`.

### 💡 Why
The project already has a complete Firebase SDK setup for its current requirements. The common SDKs (Auth, Firestore, Storage, and Functions) are already initialized and exported. Leaving the `TODO` in place is misleading and contributes to code debt.

### ✅ Verification
- Manually inspected `src/lib/firebase.ts` to ensure only the target comments were removed.
- Verified that `auth`, `firestore`, `storage`, and `functions` are correctly exported.
- Attempted to run `pnpm run lint` and `pnpm run typecheck`, but these failed due to pre-existing environment issues (missing `node_modules` and network restrictions).

### ✨ Result
Cleaner, more accurate codebase without unnecessary placeholder comments.

---
*PR created automatically by Jules for task [9859639692167726077](https://jules.google.com/task/9859639692167726077) started by @AndresDevelopers*