### PR TITLE
🔒 [security fix] Restrict access to member data in Firestore

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -32,8 +32,7 @@ service cloud.firestore {
     
     // Allow read/write access for members collection
     match /c_miembros/{document} {
-      allow read: if true;
-      allow write: if true;
+      allow read, write: if signedIn();
     }
     
     match /c_anotaciones/{document} {


### PR DESCRIPTION
### 🔒 Security Fix: Restrict Access to Member Data

#### 🎯 What
I have updated the Firestore security rules for the `c_miembros` collection. The previous rules allowed global read and write access to anyone, including unauthenticated users. The new rules now require users to be signed in to perform any operation on this collection.

#### ⚠️ Risk
Leaving the `c_miembros` collection with global access presented a significant security risk. Sensitive member information, such as names, phone numbers, and birth dates, was exposed to the public. Malicious actors could have read, modified, or deleted this data without any authorization.

#### 🛡️ Solution
I modified `firestore.rules` to replace the insecure `allow read: if true;` and `allow write: if true;` statements with a single `allow read, write: if signedIn();` statement. This ensures that only authenticated users can access or modify member data, which is the standard security practice for this type of application.

#### ✅ Verification
- Manually reviewed the `firestore.rules` file to ensure the change was applied correctly.
- Confirmed that the `signedIn()` helper function is correctly defined and used in other parts of the rules.
- Verified that no other rules were negatively impacted by this change.


---
*PR created automatically by Jules for task [2524468187031218456](https://jules.google.com/task/2524468187031218456) started by @AndresDevelopers*