### PR TITLE
🧪 implement unit tests for role privileges and normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "postinstall": "patch-package || echo 'No patches to apply'",
     "approve-builds": "pnpm approve-builds",
     "changelog": "node scripts/generate-changelog.js",
-    "setup-hooks": "node scripts/setup-hooks.js"
+    "setup-hooks": "node scripts/setup-hooks.js",
+    "test:roles": "node --experimental-strip-types scripts/test-roles.ts"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",

--- a/scripts/test-roles.ts
+++ b/scripts/test-roles.ts
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import {
+  normalizeRole,
+  canManageSettings,
+  hasLeadershipPrivileges,
+  canViewSettings,
+} from '../src/lib/roles.ts';
+import type { UserRole } from '../src/lib/roles.ts';
+
+test('normalizeRole', async (t) => {
+  await t.test('normalizes roles correctly', () => {
+    assert.strictEqual(normalizeRole('secretary'), 'secretary');
+    assert.strictEqual(normalizeRole('admin'), 'secretary');
+    assert.strictEqual(normalizeRole('president'), 'president');
+    assert.strictEqual(normalizeRole('presidente'), 'president');
+    assert.strictEqual(normalizeRole('counselor'), 'counselor');
+    assert.strictEqual(normalizeRole('consejero'), 'counselor');
+    assert.strictEqual(normalizeRole('consejera'), 'counselor');
+    assert.strictEqual(normalizeRole('other'), 'other');
+    assert.strictEqual(normalizeRole('otro'), 'other');
+  });
+
+  await t.test('handles whitespace and case', () => {
+    assert.strictEqual(normalizeRole('  PRESIDENT  '), 'president');
+    assert.strictEqual(normalizeRole('Secretary '), 'secretary');
+  });
+
+  await t.test('defaults to user for unknown roles', () => {
+    assert.strictEqual(normalizeRole('unknown'), 'user');
+    assert.strictEqual(normalizeRole(''), 'user');
+    assert.strictEqual(normalizeRole(undefined), 'user');
+    assert.strictEqual(normalizeRole(null), 'user');
+    assert.strictEqual(normalizeRole(123), 'user');
+  });
+});
+
+test('canManageSettings', () => {
+  assert.strictEqual(canManageSettings('secretary'), true);
+  assert.strictEqual(canManageSettings('president' as UserRole), false);
+  assert.strictEqual(canManageSettings('counselor' as UserRole), false);
+  assert.strictEqual(canManageSettings('user' as UserRole), false);
+  assert.strictEqual(canManageSettings('other' as UserRole), false);
+});
+
+test('hasLeadershipPrivileges', () => {
+  assert.strictEqual(hasLeadershipPrivileges('secretary'), true);
+  assert.strictEqual(hasLeadershipPrivileges('president'), true);
+  assert.strictEqual(hasLeadershipPrivileges('counselor'), true);
+  assert.strictEqual(hasLeadershipPrivileges('user'), false);
+  assert.strictEqual(hasLeadershipPrivileges('other'), false);
+});
+
+test('canViewSettings', () => {
+  assert.strictEqual(canViewSettings('secretary'), true);
+  assert.strictEqual(canViewSettings('president'), true);
+  assert.strictEqual(canViewSettings('counselor'), true);
+  assert.strictEqual(canViewSettings('user'), false);
+  assert.strictEqual(canViewSettings('other'), false);
+});


### PR DESCRIPTION
🎯 **What:**
Added comprehensive unit tests for role privilege and normalization logic in `src/lib/roles.ts`.

📊 **Coverage:**
- `canManageSettings`: Verified that only the `secretary` role has management permissions.
- `hasLeadershipPrivileges`: Confirmed that `secretary`, `president`, and `counselor` are correctly identified as leadership roles.
- `canViewSettings`: Ensured it correctly delegates to leadership privilege checks.
- `normalizeRole`: Tested various input scenarios including Spanish synonyms ('presidente', 'consejero'), case sensitivity, whitespace handling, and fallback defaults for invalid or unknown inputs.

✨ **Result:**
Improved the reliability of the application's core access control logic by providing a fast, dependency-free test suite that can be executed directly with Node 22.

---
*PR created automatically by Jules for task [11704230488745429432](https://jules.google.com/task/11704230488745429432) started by @AndresDevelopers*