### PR TITLE
🧹 Fix empty catch block in edit-baptism page

### DIFF
--- a/src/app/(main)/reports/edit-baptism/page.tsx
+++ b/src/app/(main)/reports/edit-baptism/page.tsx
@@ -11,6 +11,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
+import logger from "@/lib/logger";
 import { baptismsCollection, storage } from '@/lib/collections';
 import { Baptism } from '@/lib/types';
 import { format } from 'date-fns';
@@ -258,7 +259,11 @@ export default function EditBaptismPage() {
 
       // After saving, delete old profile photo if replaced
       if (oldProfileToDelete) {
-        try { await deleteObject(ref(storage, oldProfileToDelete)); } catch {}
+        try {
+          await deleteObject(ref(storage, oldProfileToDelete));
+        } catch (error) {
+          logger.warn({ error, message: 'Could not delete old profile photo' });
+        }
       }
 
       // Clear transient selections


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was an empty `catch` block on line 261 in `src/app/(main)/reports/edit-baptism/page.tsx` that silently swallowed errors when deleting an old profile photo.
💡 **Why:** Silently swallowing errors obscures potential bugs, makes issues harder to troubleshoot, and prevents monitoring systems from capturing the failure. Adding a logger statement properly captures and records any failures in this part of the flow.
✅ **Verification:** Verified the fix by running the typechecker (`pnpm run typecheck`) and the linter (`pnpm run lint`) and ensured that `src/lib/logger` was properly imported and that the catch block correctly passed the error state.
✨ **Result:** The codebase is now safer and healthier as any issue related to deleting previous baptism profile photos will now properly log via the logger configuration.

---
*PR created automatically by Jules for task [966934707308183378](https://jules.google.com/task/966934707308183378) started by @AndresDevelopers*