### PR TITLE
Handle flexible birthday date types; make in-app notifications idempotent; deduplicate client notifications

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -88,7 +88,7 @@ interface Service {
 interface Birthday {
     id: string;
     name: string;
-    birthDate: admin.firestore.Timestamp;
+    birthDate: admin.firestore.Timestamp | Date | string | number | { seconds: number };
     memberId?: string;
 }
 
@@ -96,7 +96,28 @@ interface MemberBasic {
     status?: string;
     firstName?: string;
     lastName?: string;
-    birthDate?: admin.firestore.Timestamp;
+    birthDate?: admin.firestore.Timestamp | Date | string | number | { seconds: number };
+}
+
+function resolveDateValue(value: unknown): Date | null {
+    if (!value) return null;
+    if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+    if (typeof value === "object" && value && "toDate" in value && typeof (value as { toDate?: unknown }).toDate === "function") {
+        const date = (value as { toDate: () => Date }).toDate();
+        return Number.isNaN(date.getTime()) ? null : date;
+    }
+    if (typeof value === "string" || typeof value === "number") {
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? null : date;
+    }
+    if (typeof value === "object" && value && "seconds" in value) {
+        const seconds = (value as { seconds?: unknown }).seconds;
+        if (typeof seconds === "number") {
+            const date = new Date(seconds * 1000);
+            return Number.isNaN(date.getTime()) ? null : date;
+        }
+    }
+    return null;
 }
 
 const getBirthdayStatusLabel = (status?: string): string | null => {
@@ -1486,10 +1507,12 @@ function getDatePartsInTimeZone(date: Date, timeZone: string): { year: number; m
 }
 
 function getBirthdayDateInEcuador(
-    birthDate: admin.firestore.Timestamp,
+    birthDate: admin.firestore.Timestamp | Date | string | number | { seconds: number },
     year: number
-): Date {
-    const parts = getDatePartsInTimeZone(birthDate.toDate(), ECUADOR_TZ);
+): Date | null {
+    const date = resolveDateValue(birthDate);
+    if (!date) return null;
+    const parts = getDatePartsInTimeZone(date, ECUADOR_TZ);
     return new Date(year, parts.month - 1, parts.day);
 }
 
@@ -1652,6 +1675,7 @@ export const dailyNotifications = functions.pubsub
             for (const doc of birthdaysSnap.docs) {
                 const b = doc.data() as Birthday;
                 const nextBirthday = getBirthdayDateInEcuador(b.birthDate, today.getFullYear());
+                if (!nextBirthday) continue;
 
                 // Resolve member status if birthday is linked to a member
                 const memberStatus = b.memberId ? memberStatusMap.get(b.memberId) : undefined;
@@ -1702,6 +1726,7 @@ export const dailyNotifications = functions.pubsub
                 if (sentBirthdays14.has(memberName) && sentBirthdaysToday.has(memberName)) continue;
 
                 const nextBirthday = getBirthdayDateInEcuador(m.birthDate, today.getFullYear());
+                if (!nextBirthday) continue;
                 const statusLabel = getBirthdayStatusLabel(m.status);
                 const nameWithStatus = statusLabel ? `${memberName} (${statusLabel})` : memberName;
 

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -19,6 +19,30 @@ import { formatRelative } from "date-fns";
 import { es } from "date-fns/locale";
 import { Skeleton } from "./ui/skeleton";
 
+function deduplicateNotifications(items: AppNotification[]): AppNotification[] {
+  const grouped = new Map<string, AppNotification>();
+  for (const notification of items) {
+    const key = notification.notificationTag
+      ? `tag:${notification.notificationTag}`
+      : `doc:${notification.id}`;
+    const existing = grouped.get(key);
+    if (!existing) {
+      grouped.set(key, notification);
+      continue;
+    }
+
+    const currentTime = notification.createdAt?.toDate?.().getTime() ?? 0;
+    const existingTime = existing.createdAt?.toDate?.().getTime() ?? 0;
+    if (currentTime > existingTime) {
+      grouped.set(key, notification);
+    }
+  }
+
+  return [...grouped.values()].sort(
+    (a, b) => (b.createdAt?.toDate?.().getTime() ?? 0) - (a.createdAt?.toDate?.().getTime() ?? 0)
+  );
+}
+
 export function NotificationBell() {
   const { user } = useAuth();
   const { t } = useI18n();
@@ -39,8 +63,9 @@ export function NotificationBell() {
       const userNotifications = snapshot.docs.map(
         (doc) => ({ id: doc.id, ...doc.data() } as AppNotification)
       );
-      setNotifications(userNotifications);
-      setHasUnread(userNotifications.some(n => !n.isRead));
+      const deduplicated = deduplicateNotifications(userNotifications);
+      setNotifications(deduplicated);
+      setHasUnread(deduplicated.some(n => !n.isRead));
     } catch (error) {
       console.error("Error fetching notifications:", error);
     }

--- a/src/lib/push-notifications-server.ts
+++ b/src/lib/push-notifications-server.ts
@@ -1,6 +1,7 @@
 
 import { firestoreAdmin, messagingAdmin } from './firebase-admin';
 import { pushSubscriptionsCollection, usersCollection, notificationsCollection } from './collections-server';
+import { createHash } from 'crypto';
 
 // FCM sendEachForMulticast supports max 500 tokens per call
 const FCM_BATCH_LIMIT = 500;
@@ -13,6 +14,27 @@ export interface PushNotificationParams {
   url?: string;
   userId?: string; // If provided, only send to this user. If not, send to all with push enabled.
   tag?: string;
+}
+
+function getEcuadorDateKey(date: Date = new Date()): string {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Guayaquil',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  return formatter.format(date);
+}
+
+function buildDeterministicInAppNotificationDocId(params: {
+  userId: string;
+  tag: string;
+  title: string;
+  body: string;
+  dateKey: string;
+}): string {
+  const base = `${params.userId}__${params.tag}__${params.dateKey}__${params.title}__${params.body}`;
+  return createHash('sha256').update(base).digest('hex');
 }
 
 /**
@@ -138,27 +160,42 @@ export async function sendServerSidePushNotification(params: PushNotificationPar
     await batch.commit();
   }
 
-  // 2. Create In-App Notifications
-  const batchSize = 500;
+  // 2. Create In-App Notifications (idempotent by user+tag+content+Ecuador day)
+  const batchSize = 200;
+  const dateKey = getEcuadorDateKey();
   for (let i = 0; i < targetUserIds.length; i += batchSize) {
-    const batch = firestoreAdmin.batch();
     const chunk = targetUserIds.slice(i, i + batchSize);
-    
-    chunk.forEach(uid => {
-      const notifRef = notificationsCollection.doc();
-      batch.set(notifRef, {
-        userId: uid,
-        title,
-        body,
-        createdAt: new Date(),
-        isRead: false,
-        actionUrl: url ?? '/',
-        actionType: 'navigate',
-        contextType: tag === 'birthday-notification' ? 'birthday' : 'general'
-      });
-    });
-    
-    await batch.commit();
+
+    await Promise.all(chunk.map(async (uid) => {
+      const notifRef = notificationsCollection.doc(
+        buildDeterministicInAppNotificationDocId({
+          userId: uid,
+          tag,
+          title,
+          body,
+          dateKey,
+        })
+      );
+      try {
+        await notifRef.create({
+          userId: uid,
+          title,
+          body,
+          createdAt: new Date(),
+          isRead: false,
+          actionUrl: url ?? '/',
+          actionType: 'navigate',
+          contextType: tag === 'birthday-notification' ? 'birthday' : 'general'
+        });
+      } catch (error) {
+        const code = typeof error === 'object' && error && 'code' in error ? (error as { code?: unknown }).code : undefined;
+        // Already exists (Firestore ALREADY_EXISTS) -> skip to keep idempotency
+        if (code === 6 || code === 'already-exists') {
+          return;
+        }
+        throw error;
+      }
+    }));
   }
 
   return {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -201,6 +201,7 @@ export type AppNotification = {
     | 'urgent_family'
     | 'missionary_assignment';
     contextId?: string;
+    notificationTag?: string | null;
 }
 
 // Member management types


### PR DESCRIPTION
### Motivation
- Normalize and safely handle multiple representations of birthday dates coming from Firestore or external sources to avoid crashes and incorrect scheduling. 
- Prevent duplicate in-app notifications when sending server-side pushes by making notification document creation idempotent per user/tag/day. 
- Improve client UX by deduplicating notifications shown in the bell (prefer the most recent per tag/doc).

### Description
- Added broad date handling by widening `birthDate` types and introducing `resolveDateValue` and safer `getBirthdayDateInEcuador` that return `null` for unparseable values, and added guards where used in `functions/src/index.ts` to skip invalid dates. 
- Implemented idempotent in-app notification creation in `src/lib/push-notifications-server.ts` by generating deterministic doc IDs with `sha256` via `buildDeterministicInAppNotificationDocId` and a per-Ecuador-day `dateKey` from `getEcuadorDateKey`, creating docs with `create()` and ignoring already-exists errors; reduced chunk size and adjusted batching logic accordingly. 
- Added client-side deduplication in `src/components/notification-bell.tsx` via `deduplicateNotifications`, which groups by `notificationTag` (or doc id) and keeps the newest notification, and updated state handling to use the deduplicated list. 
- Extended `AppNotification` type in `src/lib/types.ts` to include optional `notificationTag`. 

### Testing
- Ran TypeScript type-check (`tsc --noEmit`) to validate types after the changes and it completed successfully. 
- Executed the project's automated test suite (`npm test`) and linters as a smoke check and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee016a15e883249a92e226de7fa028)